### PR TITLE
Retina support flags

### DIFF
--- a/src/data/misc/Info.plist
+++ b/src/data/misc/Info.plist
@@ -22,5 +22,9 @@
     <string>public.app-category.utilities</string>
     <key>LSMinimumSystemVersion</key>
     <string>10.7.0</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSHighResolutionCapable</key>
+    <string>True</string>
 </dict>
 </plist>


### PR DESCRIPTION
Added flags for retina(hidpi) on mac, qt5 supports this, but it didn't work without the flags.

Fixes Issue #46 https://github.com/nitroshare/nitroshare-desktop/issues/46 < flags for Info.plist found https://github.com/nitroshare/nitroshare-desktop/issues/46#issuecomment-143418737