### PR TITLE
validate desktop file

### DIFF
--- a/src/dist/nitroshare.desktop
+++ b/src/dist/nitroshare.desktop
@@ -5,5 +5,5 @@ Name=NitroShare
 Comment=Network File Transfer Application
 Icon=nitroshare
 Exec=nitroshare
-Categories=Network;FileTransfer
-Keywords=network;transfer
+Categories=Network;FileTransfer;
+Keywords=network;transfer;


### PR DESCRIPTION
nitroshare-desktop> desktop-file-validate src/dist/nitroshare.desktop 
src/dist/nitroshare.desktop: error: value "Network;FileTransfer" for string list key "Categories" in group "Desktop Entry" does not have a semicolon (';') as trailing character
src/dist/nitroshare.desktop: error: value "network;transfer" for locale string list key "Keywords" in group "Desktop Entry" does not have a semicolon (';') as trailing character