### PR TITLE
Change German leave message

### DIFF
--- a/src/data/ts/de.ts
+++ b/src/data/ts/de.ts
@@ -91,7 +91,7 @@ Beschreibung: &quot;%2&quot;</translation>
     <message>
         <location line="+10"/>
         <source>%1 has left.</source>
-        <translation>%1 ist gegangen</translation>
+        <translation>%1 hat sich abgemeldet.</translation>
     </message>
     <message>
         <location line="+16"/>


### PR DESCRIPTION
"ist gegangen" is not really something I would say about a machine. In German it is used to describe something walking on two legs. "abmelden" makes more sense here it means "to sign off" or to "log off".